### PR TITLE
CI: Include osx in Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,49 +8,51 @@ branches:
 
 matrix:
   include:
-    - name: "Python 3.6.5 on macOS (xcode 9.4)"
+    - name: "Python 3.6.5 on macOS 10.14.4 (xcode 9.4)"
       os: osx
       osx_image: xcode9.4
-      language: shell  # 'language: python' is an error on Travis CI macOS
+      language: shell
       before_install:
         - python3 --version
         - pip3 install -U pip
-#        - pip3 install -U pytest
-#        - pip3 install codecov
-      install: pip3 install -r requirements.txt
+        - pip3 install -r requirements.txt
+      install: pip3 install -e .
       script:
         - pytest
         - flake8 mtoolnote
-    - name: "Python 3.7.3 on macOS (xcode 10.2)"
+    - name: "Python 3.7.5 on macOS 10.14.4 (xcode 10.2)"
       os: osx
       osx_image: xcode10.2
-      language: shell  # 'language: python' is an error on Travis CI macOS
+      language: shell
       before_install:
         - python3 --version
         - pip3 install -U pip
-#        - pip3 install -U pytest
-#        - pip3 install codecov
-      install: pip3 install -r requirements.txt
+        - pip3 install -r requirements.txt
+      install: pip3 install -e .
       script:
         - pytest
         - flake8 mtoolnote
-    - name: "Python 3.6 on Linux Xenial"
+    - name: "Python 3.6 on Ubuntu 16.04"
       os: linux
       language: python
+      python: 3.6
       before_install:
         - python3 --version
         - pip3 install -U pip
-      install: pip3 install -r requirements.txt
+        - pip3 install -r requirements.txt
+      install: pip3 install -e .
       script:
         - pytest
         - flake8 mtoolnote
-    - name: "Python 3.7 on Linux Xenial"
+    - name: "Python 3.7 on Ubuntu 16.04"
       os: linux
       language: python
+      python: 3.7
       before_install:
         - python3 --version
         - pip3 install -U pip
-      install: pip3 install -r requirements.txt
+        - pip3 install -r requirements.txt
+      install: pip3 install -e .
       script:
         - pytest
         - flake8 mtoolnote

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,35 @@ branches:
   - master
   - dev
 
-language: python
-python:
-  - 3.6
-  - 3.7
-
-os:
-  - linux
-  - osx
+matrix:
+  include:
+    - name: "Python 3.6.5 on macOS (xcode 9.4)"
+      os: osx
+      osx_image: xcode9.4
+      language: shell  # 'language: python' is an error on Travis CI macOS
+      before_install:
+        - python3 --version
+        - pip3 install -U pip
+        - pip3 install -U pytest
+        - pip3 install codecov
+#      script: tox
+#      after_success: python 3 -m codecov
+    - name: "Python 3.7.3 on macOS (xcode 10.2)"
+      os: osx
+      osx_image: xcode10.2
+      language: shell  # 'language: python' is an error on Travis CI macOS
+      before_install:
+        - python3 --version
+        - pip3 install -U pip
+        - pip3 install -U pytest
+        - pip3 install codecov
+#      script: tox
+    - name: "Python 3.6 on Linux"
+      os: linux
+      language: python
+    - name: "Python 3.7 on Linux"
+      os: linux
+      language: python
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,16 @@
 branches:
   only:
   - master
+  - dev
 
 language: python
 python:
   - 3.6
   - 3.7
+
+os:
+  - linux
+  - osx
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ matrix:
       before_install:
         - python3 --version
         - pip3 install -U pip
-        - pip3 install -U pytest
-        - pip3 install codecov
-#      script: tox
-#      after_success: python 3 -m codecov
+#        - pip3 install -U pytest
+#        - pip3 install codecov
+      install: pip3 install -r requirements.txt
+      script: pytest
     - name: "Python 3.7.3 on macOS (xcode 10.2)"
       os: osx
       osx_image: xcode10.2
@@ -26,21 +26,32 @@ matrix:
       before_install:
         - python3 --version
         - pip3 install -U pip
-        - pip3 install -U pytest
-        - pip3 install codecov
-#      script: tox
-    - name: "Python 3.6 on Linux"
+#        - pip3 install -U pytest
+#        - pip3 install codecov
+      install: pip3 install -r requirements.txt
+      script: pytest
+    - name: "Python 3.6 on Linux Xenial"
       os: linux
       language: python
-    - name: "Python 3.7 on Linux"
+      before_install:
+        - python3 --version
+        - pip3 install -U pip
+      install: pip3 install -r requirements.txt
+      script: pytest
+    - name: "Python 3.7 on Linux Xenial"
       os: linux
       language: python
+      before_install:
+        - python3 --version
+        - pip3 install -U pip
+      install: pip3 install -r requirements.txt
+      script: pytest
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -U tox-travis
+#install: pip install -U tox-travis
 
 # Command to run tests, e.g. python setup.py test
-script: tox
+#script: tox
 
 # Assuming you have installed the travis-ci CLI tool, after you
 # create the Github repo and add it to Travis, run the

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ matrix:
 #        - pip3 install -U pytest
 #        - pip3 install codecov
       install: pip3 install -r requirements.txt
-      script: pytest
+      script:
+        - pytest
+        - flake8 mtoolnote
     - name: "Python 3.7.3 on macOS (xcode 10.2)"
       os: osx
       osx_image: xcode10.2
@@ -29,7 +31,9 @@ matrix:
 #        - pip3 install -U pytest
 #        - pip3 install codecov
       install: pip3 install -r requirements.txt
-      script: pytest
+      script:
+        - pytest
+        - flake8 mtoolnote
     - name: "Python 3.6 on Linux Xenial"
       os: linux
       language: python
@@ -37,7 +41,9 @@ matrix:
         - python3 --version
         - pip3 install -U pip
       install: pip3 install -r requirements.txt
-      script: pytest
+      script:
+        - pytest
+        - flake8 mtoolnote
     - name: "Python 3.7 on Linux Xenial"
       os: linux
       language: python
@@ -45,7 +51,9 @@ matrix:
         - python3 --version
         - pip3 install -U pip
       install: pip3 install -r requirements.txt
-      script: pytest
+      script:
+        - pytest
+        - flake8 mtoolnote
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 #install: pip install -U tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
 
 matrix:
   include:
-    - name: "Python 3.6.5 on macOS 10.14.4 (xcode 9.4)"
+    - name: "Python 3.6.5 on macOS 10.13.6 (xcode 9.4)"
       os: osx
       osx_image: xcode9.4
       language: shell
@@ -32,7 +32,7 @@ matrix:
       script:
         - pytest
         - flake8 mtoolnote
-    - name: "Python 3.6 on Ubuntu 16.04"
+    - name: "Python 3.6.7 on Ubuntu 16.04"
       os: linux
       language: python
       python: 3.6
@@ -44,7 +44,7 @@ matrix:
       script:
         - pytest
         - flake8 mtoolnote
-    - name: "Python 3.7 on Ubuntu 16.04"
+    - name: "Python 3.7.1 on Ubuntu 16.04"
       os: linux
       language: python
       python: 3.7
@@ -62,18 +62,3 @@ matrix:
 
 # Command to run tests, e.g. python setup.py test
 #script: tox
-
-# Assuming you have installed the travis-ci CLI tool, after you
-# create the Github repo and add it to Travis, run the
-# following command to finish PyPI deployment setup:
-# $ travis encrypt --add deploy.password
-deploy:
-  provider: pypi
-  distributions: sdist bdist_wheel
-  user: robertopreste
-  password:
-    secure: PLEASE_REPLACE_ME
-  on:
-    tags: true
-    repo: robertopreste/mtoolnote
-    python: 3.6


### PR DESCRIPTION
Closes #12 

EDIT: Travis on macOS still uses python 3.7 even with a different xcode version. Will leave this as is for the time being, hopefully will be fixed in future. 